### PR TITLE
Simplify local chain update algorithm and API

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -378,7 +378,7 @@ impl<D> Wallet<D> {
 
     /// Get all the checkpoints the wallet is currently storing indexed by height.
     pub fn checkpoints(&self) -> CheckPointIter {
-        self.chain.iter_checkpoints(None)
+        self.chain.iter_checkpoints()
     }
 
     /// Returns the latest checkpoint.
@@ -500,15 +500,18 @@ impl<D> Wallet<D> {
                 // anchor tx to checkpoint with lowest height that is >= position's height
                 let anchor = self
                     .chain
-                    .checkpoints()
+                    .heights()
                     .range(height..)
                     .next()
                     .ok_or(InsertTxError::ConfirmationHeightCannotBeGreaterThanTip {
                         tip_height: self.chain.tip().map(|b| b.height()),
                         tx_height: height,
                     })
-                    .map(|(&_, cp)| ConfirmationTimeAnchor {
-                        anchor_block: cp.block_id(),
+                    .map(|(&anchor_height, &hash)| ConfirmationTimeAnchor {
+                        anchor_block: BlockId {
+                            height: anchor_height,
+                            hash,
+                        },
                         confirmation_height: height,
                         confirmation_time: time,
                     })?;

--- a/crates/bitcoind_rpc/src/lib.rs
+++ b/crates/bitcoind_rpc/src/lib.rs
@@ -280,7 +280,7 @@ impl<'a> BitcoindRpcEmitter<'a> {
                         let block = self.client.get_block(&info.hash)?;
                         let cp = last_cp
                             .clone()
-                            .extend(BlockId {
+                            .push(BlockId {
                                 height: info.height as _,
                                 hash: info.hash,
                             })

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -617,8 +617,8 @@ impl<A: Anchor> TxGraph<A> {
                     }
                 }
             })
-            .filter_map(|block| match chain.checkpoint(block.height) {
-                Some(cp) if cp.hash() == block.hash => Some(block.height),
+            .filter_map(|block| match chain.heights().get(&block.height) {
+                Some(hash) if *hash == block.hash => Some(block.height),
                 _ => None,
             })
     }

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -8,7 +8,7 @@ use bdk_chain::{
     keychain::{Balance, DerivationAdditions, KeychainTxOutIndex},
     local_chain::LocalChain,
     tx_graph::Additions,
-    ChainPosition, ConfirmationHeightAnchor, TxGraph,
+    BlockId, ChainPosition, ConfirmationHeightAnchor, TxGraph,
 };
 use bitcoin::{secp256k1::Secp256k1, BlockHash, OutPoint, Script, Transaction, TxIn, TxOut};
 use miniscript::Descriptor;
@@ -291,8 +291,10 @@ fn test_list_owned_txouts() {
             (
                 *tx,
                 local_chain
-                    .checkpoint(height)
-                    .map(|cp| cp.block_id())
+                    .heights()
+                    .get(&height)
+                    .cloned()
+                    .map(|hash| BlockId { height, hash })
                     .map(|anchor_block| ConfirmationHeightAnchor {
                         anchor_block,
                         confirmation_height: anchor_block.height,
@@ -309,9 +311,10 @@ fn test_list_owned_txouts() {
         |height: u32,
          graph: &IndexedTxGraph<ConfirmationHeightAnchor, KeychainTxOutIndex<String>>| {
             let chain_tip = local_chain
-                .checkpoint(height)
-                .map(|cp| cp.block_id())
-                .expect("block must exist");
+                .heights()
+                .get(&height)
+                .map(|&hash| BlockId { height, hash })
+                .expect(&format!("block must exist at {}", height));
             let txouts = graph
                 .graph()
                 .filter_chain_txouts(

--- a/crates/chain/tests/test_local_chain.rs
+++ b/crates/chain/tests/test_local_chain.rs
@@ -57,15 +57,15 @@ impl<'a> TestLocalChain<'a> {
                 );
             }
             ExpectedResult::Err(err) => panic!(
-                "expected error ({}), got non-error result: {:?}",
-                err, got_changeset
+                "{}: expected error ({}), got non-error result: {:?}",
+                self.name, err, got_changeset
             ),
         }
     }
 }
 
 #[test]
-fn update() {
+fn update_local_chain() {
     [
         TestLocalChain {
             name: "add first tip",
@@ -91,6 +91,14 @@ fn update() {
             new_tip: chain_update![(1, h!("B"))],
             exp: ExpectedResult::Err(CannotConnectError {
                 try_include_height: 0,
+            }),
+        },
+        TestLocalChain {
+            name: "two disjoint chains cannot merge (existing chain longer)",
+            chain: local_chain![(1, h!("A"))],
+            new_tip: chain_update![(0, h!("B"))],
+            exp: ExpectedResult::Err(CannotConnectError {
+                try_include_height: 1,
             }),
         },
         TestLocalChain {
@@ -233,14 +241,14 @@ fn update() {
                     (5, Some(h!("F"))),
                 ],
             },
-        }
+        },
     ]
     .into_iter()
     .for_each(TestLocalChain::run);
 }
 
 #[test]
-fn insert_block() {
+fn local_chain_insert_block() {
     struct TestCase {
         original: LocalChain,
         insert: (u32, BlockHash),

--- a/crates/electrum/src/electrum_ext.rs
+++ b/crates/electrum/src/electrum_ext.rs
@@ -347,7 +347,7 @@ fn construct_update_tip(
         .map(|(height, hash)| BlockId { height, hash })
         .fold(agreement_cp, |prev_cp, block| {
             Some(match prev_cp {
-                Some(cp) => cp.extend(block).expect("must extend checkpoint"),
+                Some(cp) => cp.push(block).expect("must extend checkpoint"),
                 None => CheckPoint::new(block),
             })
         })

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -316,7 +316,7 @@ async fn construct_update_tip(
         .map(|(height, hash)| BlockId { height, hash })
         .fold(agreement_cp, |prev_cp, block| {
             Some(match prev_cp {
-                Some(cp) => cp.extend(block).expect("must extend cp"),
+                Some(cp) => cp.push(block).expect("must extend cp"),
                 None => CheckPoint::new(block),
             })
         })

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -182,7 +182,7 @@ impl EsploraExt for esplora_client::BlockingClient {
             .into_iter()
             .map(|(height, hash)| BlockId { height, hash })
             .fold(first_cp, |prev_cp, block| {
-                prev_cp.extend(block).expect("must extend checkpoint")
+                prev_cp.push(block).expect("must extend checkpoint")
             });
 
         Ok(new_tip)


### PR DESCRIPTION
Three commits:

1. Re-implement update algorithm
2. Make LocalChain a `CheckPoint` and a `BTreeMap` that indexes it
3. Implement optimization mentioned by @evanlinjin
