### PR TITLE
Refactor changeset handling to use mutable references

### DIFF
--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -29,7 +29,8 @@ fn main() -> anyhow::Result<()> {
     let secp = Secp256k1::new();
     let (descriptor, _) = Descriptor::parse_descriptor(&secp, EXTERNAL)?;
     let (change_descriptor, _) = Descriptor::parse_descriptor(&secp, INTERNAL)?;
-    let (mut chain, _) = LocalChain::from_genesis(genesis_block(NETWORK).block_hash());
+    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut chain = LocalChain::from_genesis(genesis_block(NETWORK).block_hash(), &mut chain_cs);
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<&str>>::new({
         let mut index = KeychainTxOutIndex::default();
@@ -39,7 +40,6 @@ fn main() -> anyhow::Result<()> {
     });
 
     // Assume a minimum birthday height
-    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
     chain.insert_block(START_HEIGHT, START_HASH.parse()?, &mut chain_cs)?;
 
     // Configure RPC client

--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -39,7 +39,8 @@ fn main() -> anyhow::Result<()> {
     });
 
     // Assume a minimum birthday height
-    let _ = chain.insert_block(START_HEIGHT, START_HASH.parse()?)?;
+    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
+    chain.insert_block(START_HEIGHT, START_HASH.parse()?, &mut chain_cs)?;
 
     // Configure RPC client
     let url = std::env::var("RPC_URL").context("must set RPC_URL")?;
@@ -56,12 +57,13 @@ fn main() -> anyhow::Result<()> {
 
     let start = Instant::now();
 
+    let mut graph_cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
     for res in iter {
         let Event { cp, block } = res?;
         let height = cp.height();
-        let _ = chain.apply_update(cp)?;
+        chain.apply_update(cp, &mut chain_cs)?;
         if let Some(block) = block {
-            let _ = graph.apply_block_relevant(&block, height);
+            graph.apply_block_relevant(&block, height, &mut graph_cs);
             println!("Matched block {height}");
         }
     }

--- a/crates/bitcoind_rpc/src/lib.rs
+++ b/crates/bitcoind_rpc/src/lib.rs
@@ -415,7 +415,8 @@ mod test {
     #[test]
     fn test_expected_mempool_txids_accumulate_and_remove() -> anyhow::Result<()> {
         let env = TestEnv::new()?;
-        let (chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+        let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+        let chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
         let chain_tip = chain.tip();
 
         let rpc_client = bitcoincore_rpc::Client::new(

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -28,7 +28,8 @@ mod common;
 pub fn test_sync_local_chain() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let network_tip = env.rpc_client().get_block_count()?.into_model().0;
-    let (mut local_chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut local_chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
 
     let client = ClientExt::get_rpc_client(&env)?;
     let mut emitter = Emitter::new(&client, local_chain.tip(), 0, NO_EXPECTED_MEMPOOL_TXS);
@@ -165,7 +166,8 @@ fn test_into_tx_graph() -> anyhow::Result<()> {
 
     env.mine_blocks(101, None)?;
 
-    let (mut chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
     let mut indexed_tx_graph = IndexedTxGraph::<BlockId, _>::new({
         let mut index = SpkTxOutIndex::<usize>::default();
         index.insert_spk(0, addr_0.script_pubkey());
@@ -364,7 +366,8 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, Network::Regtest)?;
 
     // setup receiver
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut recv_chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
     let mut recv_graph = IndexedTxGraph::<BlockId, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -581,7 +584,9 @@ fn test_expect_tx_evicted() -> anyhow::Result<()> {
         .0;
     let spk = desc.at_derivation_index(0)?.script_pubkey();
 
-    let mut chain = LocalChain::from_genesis(genesis_block(Network::Regtest).block_hash()).0;
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut chain =
+        LocalChain::from_genesis(genesis_block(Network::Regtest).block_hash(), &mut genesis_cs);
     let chain_tip = chain.tip().block_id();
 
     let mut index = SpkTxOutIndex::default();
@@ -676,7 +681,8 @@ fn test_expect_tx_evicted() -> anyhow::Result<()> {
 #[test]
 fn test_sync_with_new_emitter_after_reorg() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
-    let (mut local_chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut local_chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
     let client = ClientExt::get_rpc_client(&env)?;
 
     env.mine_blocks(110, None)?;

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -55,8 +55,10 @@ pub fn test_sync_local_chain() -> anyhow::Result<()> {
             "emitted block hash is unexpected"
         );
 
+        let mut changeset = bdk_chain::local_chain::ChangeSet::default();
+        local_chain.apply_update(emission.checkpoint, &mut changeset)?;
         assert_eq!(
-            local_chain.apply_update(emission.checkpoint,)?,
+            changeset,
             [(height, Some(hash))].into(),
             "chain update changeset is unexpected",
         );
@@ -100,8 +102,10 @@ pub fn test_sync_local_chain() -> anyhow::Result<()> {
             "emitted block is unexpected"
         );
 
+        let mut changeset = bdk_chain::local_chain::ChangeSet::default();
+        local_chain.apply_update(emission.checkpoint, &mut changeset)?;
         assert_eq!(
-            local_chain.apply_update(emission.checkpoint,)?,
+            changeset,
             if exp_height == exp_hashes.len() - reorged_blocks.len() {
                 bdk_chain::local_chain::ChangeSet {
                     blocks: core::iter::once((height, Some(hash)))
@@ -173,10 +177,12 @@ fn test_into_tx_graph() -> anyhow::Result<()> {
     let client = ClientExt::get_rpc_client(&env)?;
     let emitter = &mut Emitter::new(&client, chain.tip(), 0, NO_EXPECTED_MEMPOOL_TXS);
 
+    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
     while let Some(emission) = emitter.next_block()? {
         let height = emission.block_height();
-        let _ = chain.apply_update(emission.checkpoint)?;
-        let indexed_additions = indexed_tx_graph.apply_block_relevant(&emission.block, height);
+        chain.apply_update(emission.checkpoint, &mut chain_cs)?;
+        let mut indexed_additions = bdk_chain::indexed_tx_graph::ChangeSet::default();
+        indexed_tx_graph.apply_block_relevant(&emission.block, height, &mut indexed_additions);
         assert!(indexed_additions.is_empty());
     }
 
@@ -199,7 +205,8 @@ fn test_into_tx_graph() -> anyhow::Result<()> {
         assert!(emitter.next_block()?.is_none());
 
         let mempool_txs = emitter.mempool()?;
-        let indexed_additions = indexed_tx_graph.batch_insert_unconfirmed(mempool_txs.update);
+        let mut indexed_additions = bdk_chain::indexed_tx_graph::ChangeSet::default();
+        indexed_tx_graph.batch_insert_unconfirmed(mempool_txs.update, &mut indexed_additions);
         assert_eq!(
             indexed_additions
                 .tx_graph
@@ -234,8 +241,9 @@ fn test_into_tx_graph() -> anyhow::Result<()> {
     {
         let emission = emitter.next_block()?.expect("must get mined block");
         let height = emission.block_height();
-        let _ = chain.apply_update(emission.checkpoint)?;
-        let indexed_additions = indexed_tx_graph.apply_block_relevant(&emission.block, height);
+        chain.apply_update(emission.checkpoint, &mut chain_cs)?;
+        let mut indexed_additions = bdk_chain::indexed_tx_graph::ChangeSet::default();
+        indexed_tx_graph.apply_block_relevant(&emission.block, height, &mut indexed_additions);
         assert!(indexed_additions.tx_graph.txs.is_empty());
         assert!(indexed_additions.tx_graph.txouts.is_empty());
         assert_eq!(indexed_additions.tx_graph.anchors, exp_anchors);
@@ -293,8 +301,10 @@ fn process_block(
     block: Block,
     block_height: u32,
 ) -> anyhow::Result<()> {
-    recv_chain.apply_header(&block.header, block_height)?;
-    let _ = recv_graph.apply_block(block, block_height);
+    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
+    recv_chain.apply_header(&block.header, block_height, &mut chain_cs)?;
+    let mut graph_cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    recv_graph.apply_block(block, block_height, &mut graph_cs);
     Ok(())
 }
 
@@ -588,12 +598,14 @@ fn test_expect_tx_evicted() -> anyhow::Result<()> {
 
     let client = ClientExt::get_rpc_client(&env)?;
     let mut emitter = Emitter::new(&client, chain.tip(), 1, core::iter::once(tx_1));
+    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
     while let Some(emission) = emitter.next_block()? {
         let height = emission.block_height();
-        chain.apply_header(&emission.block.header, height)?;
+        chain.apply_header(&emission.block.header, height, &mut chain_cs)?;
     }
 
-    let changeset = graph.batch_insert_unconfirmed(emitter.mempool()?.update);
+    let mut changeset = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.batch_insert_unconfirmed(emitter.mempool()?.update, &mut changeset);
     assert!(changeset
         .tx_graph
         .txs
@@ -645,7 +657,7 @@ fn test_expect_tx_evicted() -> anyhow::Result<()> {
         .any(|(txid, _)| txid == &txid_1));
 
     // Update graph with evicted tx.
-    let _ = graph.batch_insert_relevant_evicted_at(mempool_event.evicted);
+    graph.batch_insert_relevant_evicted_at(mempool_event.evicted, &mut changeset);
 
     let canonical_txids = graph
         .canonical_view(&chain, chain_tip, CanonicalizationParams::default())
@@ -670,8 +682,9 @@ fn test_sync_with_new_emitter_after_reorg() -> anyhow::Result<()> {
     env.mine_blocks(110, None)?;
 
     let mut emitter = Emitter::new(&client, local_chain.tip(), 0, NO_EXPECTED_MEMPOOL_TXS);
+    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
     while let Some(emission) = emitter.next_block()? {
-        let _ = local_chain.apply_update(emission.checkpoint)?;
+        local_chain.apply_update(emission.checkpoint, &mut chain_cs)?;
     }
 
     let pre_reorg_tip = local_chain.tip();
@@ -688,8 +701,8 @@ fn test_sync_with_new_emitter_after_reorg() -> anyhow::Result<()> {
     );
 
     while let Some(emission) = emitter.next_block()? {
-        let _ = local_chain
-            .apply_update(emission.checkpoint)
+        local_chain
+            .apply_update(emission.checkpoint, &mut chain_cs)
             .expect("emission checkpoint must connect with local chain");
     }
 

--- a/crates/bitcoind_rpc/tests/test_filter_iter.rs
+++ b/crates/bitcoind_rpc/tests/test_filter_iter.rs
@@ -144,9 +144,10 @@ fn event_checkpoint_connects_to_local_chain() -> anyhow::Result<()> {
     let new_hashes: BTreeMap<u32, BlockHash> = (14..=16).zip(env.reorg(3)?).collect();
 
     // Expect events from height 14 on...
+    let mut chain_cs = bdk_chain::local_chain::ChangeSet::default();
     while let Some(event) = iter.next().transpose()? {
-        let _ = chain
-            .apply_update(event.cp)
+        chain
+            .apply_update(event.cp, &mut chain_cs)
             .expect("chain update should connect");
     }
 

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -63,13 +63,15 @@ fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32
         ..new_tx(locktime)
     };
     let txid = tx.compute_txid();
-    let _ = graph.insert_tx(tx);
-    let _ = graph.insert_anchor(
+    let mut cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.insert_tx(tx, &mut cs);
+    graph.insert_anchor(
         txid,
         ConfirmationBlockTime {
             block_id,
             confirmation_time: 100,
         },
+        &mut cs,
     );
     OutPoint { txid, vout: 0 }
 }
@@ -145,7 +147,8 @@ pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
             let mut update = TxUpdate::default();
             update.seen_ats = [(tx.compute_txid(), i as u64)].into();
             update.txs = vec![Arc::new(tx)];
-            let _ = tx_graph.apply_update(update);
+            let mut cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
+            tx_graph.apply_update(update, &mut cs);
         }
     }));
     c.bench_function("many_conflicting_unconfirmed::list_canonical_txs", {
@@ -181,7 +184,8 @@ pub fn many_chained_unconfirmed(c: &mut Criterion) {
             let mut update = TxUpdate::default();
             update.seen_ats = [(txid, i as u64)].into();
             update.txs = vec![Arc::new(tx)];
-            let _ = tx_graph.apply_update(update);
+            let mut cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
+            tx_graph.apply_update(update, &mut cs);
             // Store the next prevout.
             previous_output = OutPoint::new(txid, 0);
         }
@@ -213,7 +217,9 @@ pub fn nested_conflicts(c: &mut Criterion) {
                     if last_seen % 2 == 0 {
                         last_seen /= 2;
                     }
-                    let ((_, script_pubkey), _) = tx_graph.index.next_unused_spk(()).unwrap();
+                    let mut next_cs = bdk_chain::keychain_txout::ChangeSet::default();
+                    let (_, script_pubkey) =
+                        tx_graph.index.next_unused_spk((), &mut next_cs).unwrap();
                     let value =
                         Amount::ONE_BTC - Amount::from_sat(depth as u64 * 200 - conflict_i as u64);
                     let tx = Transaction {
@@ -229,8 +235,9 @@ pub fn nested_conflicts(c: &mut Criterion) {
                     };
                     let txid = tx.compute_txid();
                     prev_ops.push(OutPoint::new(txid, 0));
-                    let _ = tx_graph.insert_seen_at(txid, last_seen as _);
-                    let _ = tx_graph.insert_tx(tx);
+                    let mut cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
+                    tx_graph.insert_seen_at(txid, last_seen as _, &mut cs);
+                    tx_graph.insert_tx(tx, &mut cs);
                 }
             }
         }

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -70,16 +70,18 @@ fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, Lo
 /// Bench performance of recovering `KeychainTxOutIndex` from changeset.
 fn do_bench(indexed_tx_graph: &KeychainTxGraph, chain: &LocalChain) {
     let desc = indexed_tx_graph.index.get_descriptor(()).unwrap();
-    let changeset = indexed_tx_graph.initial_changeset();
+    let mut changeset = indexed_tx_graph.initial_changeset();
 
     // Now recover
-    let (graph, _cs) =
-        KeychainTxGraph::from_changeset(changeset, |cs| -> Result<_, InsertDescriptorError<_>> {
+    let graph = KeychainTxGraph::from_changeset(
+        |cs| -> Result<_, InsertDescriptorError<_>> {
             let mut index = KeychainTxOutIndex::from_changeset(LOOKAHEAD, USE_SPK_CACHE, cs);
             let _ = index.insert_descriptor((), desc.clone())?;
             Ok(index)
-        })
-        .unwrap();
+        },
+        &mut changeset,
+    )
+    .unwrap();
 
     // Check balance
     let chain_tip = chain.tip().block_id();

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -92,9 +92,11 @@ fn do_bench(indexed_tx_graph: &KeychainTxGraph, chain: &LocalChain) {
 
 pub fn reindex_tx_graph(c: &mut Criterion) {
     let (graph, chain) = std::hint::black_box(setup(|graph, _chain| {
+        let mut cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
+        let mut idx_cs = bdk_chain::keychain_txout::ChangeSet::default();
         // Add relevant txs to graph
         for i in 0..TX_CT {
-            let script_pubkey = graph.index.reveal_next_spk(()).unwrap().0 .1;
+            let script_pubkey = graph.index.reveal_next_spk((), &mut idx_cs).unwrap().1;
             let tx = Transaction {
                 input: vec![TxIn::default()],
                 output: vec![TxOut {
@@ -107,10 +109,10 @@ pub fn reindex_tx_graph(c: &mut Criterion) {
             let mut update = TxUpdate::default();
             update.seen_ats = [(txid, i as u64)].into();
             update.txs = vec![Arc::new(tx)];
-            let _ = graph.apply_update(update);
+            graph.apply_update(update, &mut cs);
         }
         // Reveal some SPKs
-        let _ = graph.index.reveal_to_target((), LAST_REVEALED);
+        let _ = graph.index.reveal_to_target((), LAST_REVEALED, &mut idx_cs);
     }));
 
     c.bench_function("reindex_tx_graph", {

--- a/crates/chain/src/indexed_tx_graph.rs
+++ b/crates/chain/src/indexed_tx_graph.rs
@@ -92,11 +92,15 @@ where
 
     /// Reconstruct an [`IndexedTxGraph`] from persisted graph + indexer state.
     ///
-    /// 1. Rebuilds the `TxGraph` from `changeset.tx_graph`.
-    /// 2. Calls your `indexer_from_changeset` closure on `changeset.indexer` to restore any state
-    ///    your indexer needs beyond its raw changeset.
-    /// 3. Runs a full `.reindex()`, returning its `ChangeSet` to describe any additional updates
-    ///    applied.
+    /// `cs` is read for the persisted state to load from and is then **rewritten** with the
+    /// reconstructed state — which includes the original data plus any deltas produced by the
+    /// internal `.reindex()` pass. Save `cs` after this call to persist those deltas.
+    ///
+    /// 1. Rebuilds the `TxGraph` from `cs.tx_graph`.
+    /// 2. Calls your `indexer_from_changeset` closure on `cs.indexer` to restore any state your
+    ///    indexer needs beyond its raw changeset.
+    /// 3. Runs a full `.reindex()`.
+    /// 4. Writes the full reconstructed state back into `cs`.
     ///
     /// # Errors
     ///
@@ -112,12 +116,12 @@ where
     /// # use bdk_testenv::anyhow;
     /// # use miniscript::{Descriptor, DescriptorPublicKey};
     /// # use std::str::FromStr;
-    /// # let persisted_changeset = ChangeSet::<BlockId, _>::default();
+    /// # let mut persisted_changeset = ChangeSet::<BlockId, _>::default();
     /// # let persisted_desc = Some(Descriptor::<DescriptorPublicKey>::from_str("")?);
     /// # let persisted_change_desc = Some(Descriptor::<DescriptorPublicKey>::from_str("")?);
     ///
-    /// let (graph, reindex_cs) =
-    ///     IndexedTxGraph::from_changeset(persisted_changeset, move |idx_cs| -> anyhow::Result<_> {
+    /// let graph = IndexedTxGraph::from_changeset(
+    ///     move |idx_cs| -> anyhow::Result<_> {
     ///         // e.g. KeychainTxOutIndex needs descriptors that weren’t in its change set.
     ///         let mut idx = KeychainTxOutIndex::from_changeset(DEFAULT_LOOKAHEAD, true, idx_cs);
     ///         if let Some(desc) = persisted_desc {
@@ -127,22 +131,31 @@ where
     ///             idx.insert_descriptor("internal", desc)?;
     ///         }
     ///         Ok(idx)
-    ///     })?;
+    ///     },
+    ///     &mut persisted_changeset,
+    /// )?;
+    /// // `persisted_changeset` now contains the original data plus any reindex deltas.
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn from_changeset<F, E>(
-        changeset: ChangeSet<A, I::ChangeSet>,
+    pub fn from_changeset<F, E, C>(
         indexer_from_changeset: F,
-    ) -> Result<(Self, ChangeSet<A, I::ChangeSet>), E>
+        cs: &mut C,
+    ) -> Result<Self, E>
     where
         F: FnOnce(I::ChangeSet) -> Result<I, E>,
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
     {
-        let graph = TxGraph::<A>::from_changeset(changeset.tx_graph);
-        let index = indexer_from_changeset(changeset.indexer)?;
+        let inner = cs.as_mut();
+        let graph = TxGraph::<A>::from_changeset(core::mem::take(&mut inner.tx_graph));
+        let index = indexer_from_changeset(core::mem::take(&mut inner.indexer))?;
         let mut out = Self { graph, index };
-        let mut reindex_cs = ChangeSet::<A, I::ChangeSet>::default();
-        out.reindex(&mut reindex_cs);
-        Ok((out, reindex_cs))
+        // `reindex` mutates the indexer state to reflect matches against the loaded tx graph.
+        // Its delta is subsumed by `initial_changeset` below, so we discard the explicit delta
+        // here.
+        let mut reindex_delta = ChangeSet::<A, I::ChangeSet>::default();
+        out.reindex(&mut reindex_delta);
+        *inner = out.initial_changeset();
+        Ok(out)
     }
 
     /// Synchronizes the indexer to reflect every entry in the transaction graph.

--- a/crates/chain/src/indexed_tx_graph.rs
+++ b/crates/chain/src/indexed_tx_graph.rs
@@ -140,24 +140,27 @@ where
         let graph = TxGraph::<A>::from_changeset(changeset.tx_graph);
         let index = indexer_from_changeset(changeset.indexer)?;
         let mut out = Self { graph, index };
-        let out_changeset = out.reindex();
-        Ok((out, out_changeset))
+        let mut reindex_cs = ChangeSet::<A, I::ChangeSet>::default();
+        out.reindex(&mut reindex_cs);
+        Ok((out, reindex_cs))
     }
 
     /// Synchronizes the indexer to reflect every entry in the transaction graph.
     ///
     /// Iterates over **all** full transactions and floating outputs in `self.graph`, passing each
     /// into `self.index`. Any indexer-side changes produced (via `index_tx` or `index_txout`) are
-    /// merged into a fresh `ChangeSet`, which is then returned.
-    pub fn reindex(&mut self) -> ChangeSet<A, I::ChangeSet> {
-        let mut changeset = ChangeSet::<A, I::ChangeSet>::default();
+    /// written into `out`.
+    pub fn reindex<C>(&mut self, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
+        let changeset = out.as_mut();
         for tx in self.graph.full_txs() {
             changeset.indexer.merge(self.index.index_tx(&tx));
         }
         for (op, txout) in self.graph.floating_txouts() {
             changeset.indexer.merge(self.index.index_txout(op, txout));
         }
-        changeset
     }
 
     fn index_tx_graph_changeset(
@@ -176,46 +179,74 @@ where
 
     /// Apply an `update` directly.
     ///
-    /// `update` is a [`tx_graph::TxUpdate<A>`] and the resultant changes is returned as
-    /// [`ChangeSet`].
+    /// `update` is a [`tx_graph::TxUpdate<A>`]. Any resultant changes are written into `out`.
     ///
     /// **Note**: Transactions in the `update` without temporal context (anchors or seen_ats)
     /// will be stored but will not be considered canonical. See [`tx_graph::TxUpdate`] for
     /// more details.
-    pub fn apply_update(&mut self, update: tx_graph::TxUpdate<A>) -> ChangeSet<A, I::ChangeSet> {
+    pub fn apply_update<C>(&mut self, update: tx_graph::TxUpdate<A>, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
+        let cs = out.as_mut();
         let tx_graph = self.graph.apply_update(update);
         let indexer = self.index_tx_graph_changeset(&tx_graph);
-        ChangeSet { tx_graph, indexer }
+        cs.tx_graph.merge(tx_graph);
+        cs.indexer.merge(indexer);
     }
 
     /// Insert a floating `txout` of given `outpoint`.
-    pub fn insert_txout(&mut self, outpoint: OutPoint, txout: TxOut) -> ChangeSet<A, I::ChangeSet> {
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn insert_txout<C>(&mut self, outpoint: OutPoint, txout: TxOut, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
+        let cs = out.as_mut();
         let graph = self.graph.insert_txout(outpoint, txout);
         let indexer = self.index_tx_graph_changeset(&graph);
-        ChangeSet {
-            tx_graph: graph,
-            indexer,
-        }
+        cs.tx_graph.merge(graph);
+        cs.indexer.merge(indexer);
     }
 
     /// Insert and index a transaction into the graph.
-    pub fn insert_tx<T: Into<Arc<Transaction>>>(&mut self, tx: T) -> ChangeSet<A, I::ChangeSet> {
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn insert_tx<T, C>(&mut self, tx: T, out: &mut C)
+    where
+        T: Into<Arc<Transaction>>,
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
+        let cs = out.as_mut();
         let tx_graph = self.graph.insert_tx(tx);
         let indexer = self.index_tx_graph_changeset(&tx_graph);
-        ChangeSet { tx_graph, indexer }
+        cs.tx_graph.merge(tx_graph);
+        cs.indexer.merge(indexer);
     }
 
     /// Insert an `anchor` for a given transaction.
-    pub fn insert_anchor(&mut self, txid: Txid, anchor: A) -> ChangeSet<A, I::ChangeSet> {
-        self.graph.insert_anchor(txid, anchor).into()
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn insert_anchor<C>(&mut self, txid: Txid, anchor: A, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
+        let tx_graph = self.graph.insert_anchor(txid, anchor);
+        out.as_mut().tx_graph.merge(tx_graph);
     }
 
     /// Insert a unix timestamp of when a transaction is seen in the mempool.
     ///
     /// This is used for transaction conflict resolution in [`TxGraph`] where the transaction with
     /// the later last-seen is prioritized.
-    pub fn insert_seen_at(&mut self, txid: Txid, seen_at: u64) -> ChangeSet<A, I::ChangeSet> {
-        self.graph.insert_seen_at(txid, seen_at).into()
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn insert_seen_at<C>(&mut self, txid: Txid, seen_at: u64, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
+        let tx_graph = self.graph.insert_seen_at(txid, seen_at);
+        out.as_mut().tx_graph.merge(tx_graph);
     }
 
     /// Inserts the given `evicted_at` for `txid`.
@@ -223,12 +254,14 @@ where
     /// The `evicted_at` timestamp represents the last known time when the transaction was observed
     /// to be missing from the mempool. If `txid` was previously recorded with an earlier
     /// `evicted_at` value, it is updated only if the new value is greater.
-    pub fn insert_evicted_at(&mut self, txid: Txid, evicted_at: u64) -> ChangeSet<A, I::ChangeSet> {
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn insert_evicted_at<C>(&mut self, txid: Txid, evicted_at: u64, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
         let tx_graph = self.graph.insert_evicted_at(txid, evicted_at);
-        ChangeSet {
-            tx_graph,
-            ..Default::default()
-        }
+        out.as_mut().tx_graph.merge(tx_graph);
     }
 
     /// Batch inserts `(txid, evicted_at)` pairs for `txid`s that the graph is tracking.
@@ -236,15 +269,17 @@ where
     /// The `evicted_at` timestamp represents the last known time when the transaction was observed
     /// to be missing from the mempool. If `txid` was previously recorded with an earlier
     /// `evicted_at` value, it is updated only if the new value is greater.
-    pub fn batch_insert_relevant_evicted_at(
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn batch_insert_relevant_evicted_at<C>(
         &mut self,
         evicted_ats: impl IntoIterator<Item = (Txid, u64)>,
-    ) -> ChangeSet<A, I::ChangeSet> {
+        out: &mut C,
+    ) where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
         let tx_graph = self.graph.batch_insert_relevant_evicted_at(evicted_ats);
-        ChangeSet {
-            tx_graph,
-            ..Default::default()
-        }
+        out.as_mut().tx_graph.merge(tx_graph);
     }
 
     /// Batch insert transactions, filtering out those that are irrelevant.
@@ -254,10 +289,16 @@ where
     /// Relevancy is determined by the internal [`Indexer::is_tx_relevant`] implementation of `I`.
     /// A transaction that conflicts with a relevant transaction is also considered relevant.
     /// Irrelevant transactions in `txs` will be ignored.
-    pub fn batch_insert_relevant<T: Into<Arc<Transaction>>>(
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn batch_insert_relevant<T, C>(
         &mut self,
         txs: impl IntoIterator<Item = (T, impl IntoIterator<Item = A>)>,
-    ) -> ChangeSet<A, I::ChangeSet> {
+        out: &mut C,
+    ) where
+        T: Into<Arc<Transaction>>,
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
         // The algorithm below allows for non-topologically ordered transactions by using two loops.
         // This is achieved by:
         // 1. insert all txs into the index. If they are irrelevant then that's fine it will just
@@ -269,23 +310,20 @@ where
             .map(|(tx, anchors)| (<T as Into<Arc<Transaction>>>::into(tx), anchors))
             .collect::<Vec<_>>();
 
-        let mut indexer = I::ChangeSet::default();
+        let cs = out.as_mut();
         for (tx, _) in &txs {
-            indexer.merge(self.index.index_tx(tx));
+            cs.indexer.merge(self.index.index_tx(tx));
         }
 
-        let mut tx_graph = tx_graph::ChangeSet::default();
         for (tx, anchors) in txs {
             if self.is_tx_or_conflict_relevant(&tx) {
                 let txid = tx.compute_txid();
-                tx_graph.merge(self.graph.insert_tx(tx.clone()));
+                cs.tx_graph.merge(self.graph.insert_tx(tx.clone()));
                 for anchor in anchors {
-                    tx_graph.merge(self.graph.insert_anchor(txid, anchor));
+                    cs.tx_graph.merge(self.graph.insert_anchor(txid, anchor));
                 }
             }
         }
-
-        ChangeSet { tx_graph, indexer }
     }
 
     /// Batch insert unconfirmed transactions, filtering out those that are irrelevant.
@@ -297,10 +335,16 @@ where
     /// Items of `txs` are tuples containing the transaction and a *last seen* timestamp. The
     /// *last seen* communicates when the transaction is last seen in the mempool which is used for
     /// conflict-resolution in [`TxGraph`] (refer to [`TxGraph::insert_seen_at`] for details).
-    pub fn batch_insert_relevant_unconfirmed<T: Into<Arc<Transaction>>>(
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn batch_insert_relevant_unconfirmed<T, C>(
         &mut self,
         unconfirmed_txs: impl IntoIterator<Item = (T, u64)>,
-    ) -> ChangeSet<A, I::ChangeSet> {
+        out: &mut C,
+    ) where
+        T: Into<Arc<Transaction>>,
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
         // The algorithm below allows for non-topologically ordered transactions by using two loops.
         // This is achieved by:
         // 1. insert all txs into the index. If they are irrelevant then that's fine it will just
@@ -312,9 +356,9 @@ where
             .map(|(tx, last_seen)| (<T as Into<Arc<Transaction>>>::into(tx), last_seen))
             .collect::<Vec<_>>();
 
-        let mut indexer = I::ChangeSet::default();
+        let cs = out.as_mut();
         for (tx, _) in &txs {
-            indexer.merge(self.index.index_tx(tx));
+            cs.indexer.merge(self.index.index_tx(tx));
         }
 
         let graph = self.graph.batch_insert_unconfirmed(
@@ -324,10 +368,7 @@ where
                 .collect::<Vec<_>>(),
         );
 
-        ChangeSet {
-            tx_graph: graph,
-            indexer,
-        }
+        cs.tx_graph.merge(graph);
     }
 
     /// Batch insert unconfirmed transactions.
@@ -338,17 +379,22 @@ where
     ///
     /// To filter out irrelevant transactions, use [`batch_insert_relevant_unconfirmed`] instead.
     ///
+    /// Any resultant changes are written into `out`.
+    ///
     /// [`batch_insert_relevant_unconfirmed`]: IndexedTxGraph::batch_insert_relevant_unconfirmed
-    pub fn batch_insert_unconfirmed<T: Into<Arc<Transaction>>>(
+    pub fn batch_insert_unconfirmed<T, C>(
         &mut self,
         txs: impl IntoIterator<Item = (T, u64)>,
-    ) -> ChangeSet<A, I::ChangeSet> {
+        out: &mut C,
+    ) where
+        T: Into<Arc<Transaction>>,
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
+        let cs = out.as_mut();
         let graph = self.graph.batch_insert_unconfirmed(txs);
         let indexer = self.index_tx_graph_changeset(&graph);
-        ChangeSet {
-            tx_graph: graph,
-            indexer,
-        }
+        cs.tx_graph.merge(graph);
+        cs.indexer.merge(indexer);
     }
 }
 
@@ -367,18 +413,19 @@ where
     /// Relevancy is determined by the internal [`Indexer::is_tx_relevant`] implementation of `I`.
     /// A transaction that conflicts with a relevant transaction is also considered relevant.
     /// Irrelevant transactions in `block` will be ignored.
-    pub fn apply_block_relevant(
-        &mut self,
-        block: &Block,
-        height: u32,
-    ) -> ChangeSet<A, I::ChangeSet> {
+    ///
+    /// Any resultant changes are written into `out`.
+    pub fn apply_block_relevant<C>(&mut self, block: &Block, height: u32, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
         let block_id = BlockId {
             hash: block.block_hash(),
             height,
         };
-        let mut changeset = ChangeSet::<A, I::ChangeSet>::default();
+        let cs = out.as_mut();
         for (tx_pos, tx) in block.txdata.iter().enumerate() {
-            changeset.indexer.merge(self.index.index_tx(tx));
+            cs.indexer.merge(self.index.index_tx(tx));
             if self.is_tx_or_conflict_relevant(tx) {
                 let txid = tx.compute_txid();
                 let anchor = TxPosInBlock {
@@ -387,13 +434,10 @@ where
                     tx_pos,
                 }
                 .into();
-                changeset.tx_graph.merge(self.graph.insert_tx(tx.clone()));
-                changeset
-                    .tx_graph
-                    .merge(self.graph.insert_anchor(txid, anchor));
+                cs.tx_graph.merge(self.graph.insert_tx(tx.clone()));
+                cs.tx_graph.merge(self.graph.insert_anchor(txid, anchor));
             }
         }
-        changeset
     }
 
     /// Batch insert all transactions of the given `block` of `height`.
@@ -402,12 +446,18 @@ where
     ///
     /// To only insert relevant transactions, use [`apply_block_relevant`] instead.
     ///
+    /// Any resultant changes are written into `out`.
+    ///
     /// [`apply_block_relevant`]: IndexedTxGraph::apply_block_relevant
-    pub fn apply_block(&mut self, block: Block, height: u32) -> ChangeSet<A, I::ChangeSet> {
+    pub fn apply_block<C>(&mut self, block: Block, height: u32, out: &mut C)
+    where
+        C: AsMut<ChangeSet<A, I::ChangeSet>>,
+    {
         let block_id = BlockId {
             hash: block.block_hash(),
             height,
         };
+        let cs = out.as_mut();
         let mut graph = tx_graph::ChangeSet::default();
         for (tx_pos, tx) in block.txdata.iter().enumerate() {
             let anchor = TxPosInBlock {
@@ -420,10 +470,8 @@ where
             graph.merge(self.graph.insert_tx(tx.clone()));
         }
         let indexer = self.index_tx_graph_changeset(&graph);
-        ChangeSet {
-            tx_graph: graph,
-            indexer,
-        }
+        cs.tx_graph.merge(graph);
+        cs.indexer.merge(indexer);
     }
 }
 
@@ -495,6 +543,12 @@ impl<A: Anchor, IA: Merge> Merge for ChangeSet<A, IA> {
 
     fn is_empty(&self) -> bool {
         self.tx_graph.is_empty() && self.indexer.is_empty()
+    }
+}
+
+impl<A, IA> AsMut<ChangeSet<A, IA>> for ChangeSet<A, IA> {
+    fn as_mut(&mut self) -> &mut Self {
+        self
     }
 }
 

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -74,8 +74,9 @@ pub const DEFAULT_LOOKAHEAD: u32 = 25;
 ///
 /// # Change sets
 ///
-/// Methods that can update the last revealed index or add keychains will return [`ChangeSet`] to
-/// report these changes. This should be persisted for future recovery.
+/// Methods that can update the last revealed index or add keychains take a `&mut ChangeSet`
+/// argument and write their changes into it. The accumulated changeset should be persisted for
+/// future recovery.
 ///
 /// ## Synopsis
 ///
@@ -105,7 +106,9 @@ pub const DEFAULT_LOOKAHEAD: u32 = 25;
 /// let _ = txout_index.insert_descriptor(MyKeychain::Internal, internal_descriptor)?;
 /// let _ = txout_index.insert_descriptor(MyKeychain::MyAppUser { user_id: 42 }, descriptor_42)?;
 ///
-/// let new_spk_for_user = txout_index.reveal_next_spk(MyKeychain::MyAppUser{ user_id: 42 });
+/// let mut changeset = bdk_chain::keychain_txout::ChangeSet::default();
+/// let new_spk_for_user =
+///     txout_index.reveal_next_spk(MyKeychain::MyAppUser { user_id: 42 }, &mut changeset);
 /// # Ok::<_, bdk_chain::indexer::keychain_txout::InsertDescriptorError<_>>(())
 /// ```
 ///
@@ -537,8 +540,13 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// Store lookahead scripts until `target_index` (inclusive).
     ///
     /// This does not change the global `lookahead` setting.
-    pub fn lookahead_to_target(&mut self, keychain: K, target_index: u32) -> ChangeSet {
-        let mut changeset = ChangeSet::default();
+    ///
+    /// Any changes made by this method are written into `out`.
+    pub fn lookahead_to_target<C>(&mut self, keychain: K, target_index: u32, out: &mut C)
+    where
+        C: AsMut<ChangeSet>,
+    {
+        let changeset = out.as_mut();
         if let Some((next_index, _)) = self.next_index(keychain.clone()) {
             let temp_lookahead = (target_index + 1)
                 .checked_sub(next_index)
@@ -548,8 +556,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
                 self.replenish_inner_index_keychain(keychain, temp_lookahead);
             }
         }
-        self._empty_stage_into_changeset(&mut changeset);
-        changeset
+        self._empty_stage_into_changeset(changeset);
     }
 
     fn replenish_inner_index_did(&mut self, did: DescriptorId, lookahead: u32) {
@@ -793,15 +800,17 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     }
 
     /// Convenience method to call [`Self::reveal_to_target`] on multiple keychains.
-    pub fn reveal_to_target_multi(&mut self, keychains: &BTreeMap<K, u32>) -> ChangeSet {
-        let mut changeset = ChangeSet::default();
-
+    ///
+    /// Any changes made by this method are written into `out`.
+    pub fn reveal_to_target_multi<C>(&mut self, keychains: &BTreeMap<K, u32>, out: &mut C)
+    where
+        C: AsMut<ChangeSet>,
+    {
+        let changeset = out.as_mut();
         for (keychain, &index) in keychains {
-            self._reveal_to_target(&mut changeset, keychain.clone(), index);
+            self._reveal_to_target(changeset, keychain.clone(), index);
         }
-
-        self._empty_stage_into_changeset(&mut changeset);
-        changeset
+        self._empty_stage_into_changeset(changeset);
     }
 
     /// Reveals script pubkeys of the `keychain`'s descriptor **up to and including** the
@@ -811,21 +820,24 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// the `target_index` is in the hardened index range), this method will make a best-effort and
     /// reveal up to the last possible index.
     ///
-    /// This returns list of newly revealed indices (alongside their scripts) and a
-    /// [`ChangeSet`], which reports updates to the latest revealed index. If no new script
-    /// pubkeys are revealed, then both of these will be empty.
+    /// Returns the list of newly revealed indices (alongside their scripts). If no new script
+    /// pubkeys are revealed, the returned vector will be empty. Any changes to the latest
+    /// revealed index are written into `out`.
     ///
-    /// Returns None if the provided `keychain` doesn't exist.
-    #[must_use]
-    pub fn reveal_to_target(
+    /// Returns `None` if the provided `keychain` doesn't exist.
+    pub fn reveal_to_target<C>(
         &mut self,
         keychain: K,
         target_index: u32,
-    ) -> Option<(Vec<Indexed<ScriptBuf>>, ChangeSet)> {
-        let mut changeset = ChangeSet::default();
-        let revealed_spks = self._reveal_to_target(&mut changeset, keychain, target_index)?;
-        self._empty_stage_into_changeset(&mut changeset);
-        Some((revealed_spks, changeset))
+        out: &mut C,
+    ) -> Option<Vec<Indexed<ScriptBuf>>>
+    where
+        C: AsMut<ChangeSet>,
+    {
+        let changeset = out.as_mut();
+        let revealed_spks = self._reveal_to_target(changeset, keychain, target_index)?;
+        self._empty_stage_into_changeset(changeset);
+        Some(revealed_spks)
     }
     fn _reveal_to_target(
         &mut self,
@@ -849,21 +861,24 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
 
     /// Attempts to reveal the next script pubkey for `keychain`.
     ///
-    /// Returns the derivation index of the revealed script pubkey, the revealed script pubkey and a
-    /// [`ChangeSet`] which represents changes in the last revealed index (if any).
-    /// Returns None if the provided keychain doesn't exist.
+    /// Returns the derivation index of the revealed script pubkey and the revealed script pubkey.
+    /// Any changes to the last revealed index are written into `out`.
+    /// Returns `None` if the provided keychain doesn't exist.
     ///
-    /// When a new script cannot be revealed, we return the last revealed script and an empty
-    /// [`ChangeSet`]. There are two scenarios when a new script pubkey cannot be derived:
+    /// When a new script cannot be revealed, we return the last revealed script and nothing is
+    /// written into `out`. There are two scenarios when a new script pubkey cannot be derived:
     ///
     ///  1. The descriptor has no wildcard and already has one script revealed.
     ///  2. The descriptor has already revealed scripts up to the numeric bound.
     ///  3. There is no descriptor associated with the given keychain.
-    pub fn reveal_next_spk(&mut self, keychain: K) -> Option<(Indexed<ScriptBuf>, ChangeSet)> {
-        let mut changeset = ChangeSet::default();
-        let indexed_spk = self._reveal_next_spk(&mut changeset, keychain)?;
-        self._empty_stage_into_changeset(&mut changeset);
-        Some((indexed_spk, changeset))
+    pub fn reveal_next_spk<C>(&mut self, keychain: K, out: &mut C) -> Option<Indexed<ScriptBuf>>
+    where
+        C: AsMut<ChangeSet>,
+    {
+        let changeset = out.as_mut();
+        let indexed_spk = self._reveal_next_spk(changeset, keychain)?;
+        self._empty_stage_into_changeset(changeset);
+        Some(indexed_spk)
     }
     fn _reveal_next_spk(
         &mut self,
@@ -893,19 +908,24 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// has used all scripts up to the derivation bounds, then the last derived script pubkey will
     /// be returned.
     ///
+    /// Any changes to the last revealed index are written into `out`.
+    ///
     /// Returns `None` if there are no script pubkeys that have been used and no new script pubkey
     /// could be revealed (see [`reveal_next_spk`] for when this happens).
     ///
     /// [`reveal_next_spk`]: Self::reveal_next_spk
-    pub fn next_unused_spk(&mut self, keychain: K) -> Option<(Indexed<ScriptBuf>, ChangeSet)> {
-        let mut changeset = ChangeSet::default();
+    pub fn next_unused_spk<C>(&mut self, keychain: K, out: &mut C) -> Option<Indexed<ScriptBuf>>
+    where
+        C: AsMut<ChangeSet>,
+    {
+        let changeset = out.as_mut();
         let next_unused = self
             .unused_keychain_spks(keychain.clone())
             .next()
             .map(|(i, spk)| (i, spk.to_owned()));
-        let spk = next_unused.or_else(|| self._reveal_next_spk(&mut changeset, keychain))?;
-        self._empty_stage_into_changeset(&mut changeset);
-        Some((spk, changeset))
+        let spk = next_unused.or_else(|| self._reveal_next_spk(changeset, keychain))?;
+        self._empty_stage_into_changeset(changeset);
+        Some(spk)
     }
 
     /// Iterate over all [`OutPoint`]s that have `TxOut`s with script pubkeys derived from
@@ -1057,6 +1077,12 @@ pub struct ChangeSet {
     pub spk_cache: BTreeMap<DescriptorId, BTreeMap<u32, ScriptBuf>>,
 }
 
+impl AsMut<ChangeSet> for ChangeSet {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl Merge for ChangeSet {
     /// Merge another [`ChangeSet`] into self.
     fn merge(&mut self, other: Self) {
@@ -1169,8 +1195,9 @@ mod test {
         assert_eq!(index.next_index(0), Some((0, true)));
 
         // Now reveal some scripts
+        let mut cs = ChangeSet::default();
         for _ in 0..=reveal_to {
-            let _ = index.reveal_next_spk(0).unwrap();
+            let _ = index.reveal_next_spk(0, &mut cs).unwrap();
         }
         assert_eq!(index.last_revealed_index(0), Some(reveal_to));
 

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -249,14 +249,19 @@ where
     D: ToBlockHash + fmt::Debug + Clone,
 {
     /// Constructs a [`LocalChain`] from genesis data.
-    pub fn from_genesis(data: D) -> (Self, ChangeSet<D>) {
+    ///
+    /// The initial changeset (which the caller must persist to remember the genesis block on
+    /// reload) is written into `cs`.
+    pub fn from_genesis<C>(data: D, cs: &mut C) -> Self
+    where
+        C: AsMut<ChangeSet<D>>,
+    {
         let height = 0;
         let chain = Self {
             tip: CheckPoint::new(height, data),
         };
-        let changeset = chain.initial_changeset();
-
-        (chain, changeset)
+        cs.as_mut().merge(chain.initial_changeset());
+        chain
     }
 
     /// Constructs a [`LocalChain`] from a [`BTreeMap`] of height and data `D`.
@@ -286,7 +291,8 @@ where
             None => return Err(ApplyBlockError::MissingGenesis),
         };
 
-        let (mut chain, _) = Self::from_genesis(genesis_data);
+        let mut tmp = ChangeSet::<D>::default();
+        let mut chain = Self::from_genesis(genesis_data, &mut tmp);
         chain.apply_changeset(&changeset)?;
         debug_assert!(chain._check_changeset_is_applied(&changeset));
         Ok(chain)

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -122,12 +122,16 @@ impl LocalChain<BlockHash> {
     /// [`ApplyHeaderError::CannotConnect`] occurs if the internal call to [`apply_update`] fails.
     ///
     /// [`apply_update`]: Self::apply_update
-    pub fn apply_header_connected_to(
+    pub fn apply_header_connected_to<C>(
         &mut self,
         header: &Header,
         height: u32,
         connected_to: BlockId,
-    ) -> Result<ChangeSet, ApplyHeaderError> {
+        out: &mut C,
+    ) -> Result<(), ApplyHeaderError>
+    where
+        C: AsMut<ChangeSet>,
+    {
         let this = BlockId {
             height,
             hash: header.block_hash(),
@@ -157,7 +161,7 @@ impl LocalChain<BlockHash> {
         )
         .expect("block ids must be in order");
 
-        self.apply_update(update)
+        self.apply_update(update, out)
             .map_err(ApplyHeaderError::CannotConnect)
     }
 
@@ -168,11 +172,15 @@ impl LocalChain<BlockHash> {
     /// use the current block as `connected_to`.
     ///
     /// [`apply_header_connected_to`]: LocalChain::apply_header_connected_to
-    pub fn apply_header(
+    pub fn apply_header<C>(
         &mut self,
         header: &Header,
         height: u32,
-    ) -> Result<ChangeSet, CannotConnectError> {
+        out: &mut C,
+    ) -> Result<(), CannotConnectError>
+    where
+        C: AsMut<ChangeSet>,
+    {
         let connected_to = match height.checked_sub(1) {
             Some(prev_height) => BlockId {
                 height: prev_height,
@@ -183,7 +191,7 @@ impl LocalChain<BlockHash> {
                 hash: header.block_hash(),
             },
         };
-        self.apply_header_connected_to(header, height, connected_to)
+        self.apply_header_connected_to(header, height, connected_to, out)
             .map_err(|err| match err {
                 ApplyHeaderError::InconsistentBlocks => {
                     unreachable!("connected_to is derived from the block so is always consistent")
@@ -296,7 +304,7 @@ where
 
     /// Applies the given `update` to the chain.
     ///
-    /// The method returns [`ChangeSet`] on success. This represents the changes applied to `self`.
+    /// Any changes applied to `self` are written into `out`.
     ///
     /// There must be no ambiguity about which of the existing chain's blocks are still valid and
     /// which are now invalid. That is, the new chain must implicitly connect to a definite block in
@@ -308,14 +316,19 @@ where
     /// An error will occur if the update does not correctly connect with `self`.
     ///
     /// [module-level documentation]: crate::local_chain
-    pub fn apply_update(
+    pub fn apply_update<C>(
         &mut self,
         update: CheckPoint<D>,
-    ) -> Result<ChangeSet<D>, CannotConnectError> {
+        out: &mut C,
+    ) -> Result<(), CannotConnectError>
+    where
+        C: AsMut<ChangeSet<D>>,
+    {
         let (new_tip, changeset) = merge_chains(self.tip.clone(), update)?;
         self.tip = new_tip;
         debug_assert!(self._check_changeset_is_applied(&changeset));
-        Ok(changeset)
+        out.as_mut().merge(changeset);
+        Ok(())
     }
 
     /// Apply the given `changeset`.
@@ -341,14 +354,20 @@ where
 
     /// Insert block into a [`LocalChain`].
     ///
+    /// Any changes applied to `self` are written into `out`.
+    ///
     /// # Errors
     ///
     /// Replacing the block hash of an existing checkpoint will result in an error.
-    pub fn insert_block(
+    pub fn insert_block<C>(
         &mut self,
         height: u32,
         data: D,
-    ) -> Result<ChangeSet<D>, AlterCheckPointError> {
+        out: &mut C,
+    ) -> Result<(), AlterCheckPointError>
+    where
+        C: AsMut<ChangeSet<D>>,
+    {
         if let Some(original_cp) = self.tip.get(height) {
             let original_hash = original_cp.hash();
             if original_hash != data.to_blockhash() {
@@ -358,7 +377,7 @@ where
                     update_hash: Some(data.to_blockhash()),
                 });
             }
-            return Ok(ChangeSet::default());
+            return Ok(());
         }
 
         let mut changeset = ChangeSet::<D>::default();
@@ -374,7 +393,8 @@ where
                     .flatten()
                     .map(|d| d.to_blockhash()),
             })?;
-        Ok(changeset)
+        out.as_mut().merge(changeset);
+        Ok(())
     }
 
     /// Removes blocks from (and inclusive of) the given `block_id`.
@@ -382,14 +402,20 @@ where
     /// This will remove blocks with a height equal or greater than `block_id`, but only if
     /// `block_id` exists in the chain.
     ///
+    /// Any changes applied to `self` are written into `out`.
+    ///
     /// # Errors
     ///
     /// This will fail with [`MissingGenesisError`] if the caller attempts to disconnect from the
     /// genesis block.
-    pub fn disconnect_from(
+    pub fn disconnect_from<C>(
         &mut self,
         block_id: BlockId,
-    ) -> Result<ChangeSet<D>, MissingGenesisError> {
+        out: &mut C,
+    ) -> Result<(), MissingGenesisError>
+    where
+        C: AsMut<ChangeSet<D>>,
+    {
         let mut remove_from = Option::<CheckPoint<D>>::None;
         let mut changeset = ChangeSet::default();
         for cp in self.tip().iter() {
@@ -409,10 +435,11 @@ where
             // "earliest checkpoint to remove" is the genesis block. We disallow removing the
             // genesis block.
             Some(None) => return Err(MissingGenesisError),
-            // If there is nothing to remove, we return an empty changeset.
-            None => return Ok(ChangeSet::default()),
+            // If there is nothing to remove, we leave `out` unchanged.
+            None => return Ok(()),
         };
-        Ok(changeset)
+        out.as_mut().merge(changeset);
+        Ok(())
     }
 
     fn _check_changeset_is_applied(&self, changeset: &ChangeSet<D>) -> bool {
@@ -464,6 +491,12 @@ impl<D> Merge for ChangeSet<D> {
 
     fn is_empty(&self) -> bool {
         self.blocks.is_empty()
+    }
+}
+
+impl<D> AsMut<ChangeSet<D>> for ChangeSet<D> {
+    fn as_mut(&mut self) -> &mut Self {
+        self
     }
 }
 

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -123,10 +123,11 @@ fn relevant_conflicts() -> anyhow::Result<()> {
         /// Scans through all transactions in the blockchain + mempool.
         fn sync(&mut self) -> anyhow::Result<()> {
             let client = self.env.rpc_client();
+            let mut cs = indexed_tx_graph::ChangeSet::default();
             for height in 0..=client.get_block_count()?.into_model().0 {
                 let hash = client.get_block_hash(height)?.block_hash()?;
                 let block = client.get_block(hash)?;
-                let _ = self.graph.apply_block_relevant(&block, height as _);
+                self.graph.apply_block_relevant(&block, height as _, &mut cs);
             }
 
             let mempool_txids = client.get_raw_mempool()?.into_model()?.0;
@@ -137,9 +138,8 @@ fn relevant_conflicts() -> anyhow::Result<()> {
                     Ok((tx, 0))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let _ = self
-                .graph
-                .batch_insert_relevant_unconfirmed(unconfirmed_txs);
+            self.graph
+                .batch_insert_relevant_unconfirmed(unconfirmed_txs, &mut cs);
             Ok(())
         }
 
@@ -281,10 +281,12 @@ fn insert_relevant_txs() {
         },
     };
 
-    assert_eq!(
-        graph.batch_insert_relevant(txs.iter().cloned().map(|tx| (tx, None))),
-        changeset,
+    let mut got_changeset = indexed_tx_graph::ChangeSet::default();
+    graph.batch_insert_relevant(
+        txs.iter().cloned().map(|tx| (tx, None)),
+        &mut got_changeset,
     );
+    assert_eq!(got_changeset, changeset);
 
     // The initial changeset will also contain info about the keychain we added
     let initial_changeset = indexed_tx_graph::ChangeSet {
@@ -361,12 +363,13 @@ fn test_list_owned_txouts() {
     let mut trusted_spks: Vec<ScriptBuf> = Vec::new();
     let mut untrusted_spks: Vec<ScriptBuf> = Vec::new();
 
+    let mut reveal_cs = bdk_chain::keychain_txout::ChangeSet::default();
     {
         // we need to scope here to take immutable reference of the graph
         for _ in 0..10 {
-            let ((_, script), _) = graph
+            let (_, script) = graph
                 .index
-                .reveal_next_spk("keychain_1".to_string())
+                .reveal_next_spk("keychain_1".to_string(), &mut reveal_cs)
                 .unwrap();
             // TODO Assert indexes
             trusted_spks.push(script.to_owned());
@@ -374,9 +377,9 @@ fn test_list_owned_txouts() {
     }
     {
         for _ in 0..10 {
-            let ((_, script), _) = graph
+            let (_, script) = graph
                 .index
-                .reveal_next_spk("keychain_2".to_string())
+                .reveal_next_spk("keychain_2".to_string(), &mut reveal_cs)
                 .unwrap();
             untrusted_spks.push(script.to_owned());
         }
@@ -444,8 +447,9 @@ fn test_list_owned_txouts() {
     // Insert transactions into graph with respective anchors
     // Insert unconfirmed txs with a last_seen timestamp
 
-    let _ =
-        graph.batch_insert_relevant([&tx1, &tx2, &tx3, &tx6].iter().enumerate().map(|(i, &tx)| {
+    let mut tmp_cs = indexed_tx_graph::ChangeSet::default();
+    graph.batch_insert_relevant(
+        [&tx1, &tx2, &tx3, &tx6].iter().enumerate().map(|(i, &tx)| {
             let height = i as u32;
             (
                 tx.clone(),
@@ -457,10 +461,14 @@ fn test_list_owned_txouts() {
                         confirmation_time: 100,
                     }),
             )
-        }));
+        }),
+        &mut tmp_cs,
+    );
 
-    let _ =
-        graph.batch_insert_relevant_unconfirmed([&tx4, &tx5].iter().map(|&tx| (tx.clone(), 100)));
+    graph.batch_insert_relevant_unconfirmed(
+        [&tx4, &tx5].iter().map(|&tx| (tx.clone(), 100)),
+        &mut tmp_cs,
+    );
 
     // A helper lambda to extract and filter data from the graph.
     let fetch =
@@ -779,12 +787,13 @@ fn test_get_chain_position() {
 
         // add data to graph
         let txid = tx.compute_txid();
-        let _ = graph.insert_tx(tx);
+        let mut cs = indexed_tx_graph::ChangeSet::default();
+        graph.insert_tx(tx, &mut cs);
         if let Some(anchor) = anchor {
-            let _ = graph.insert_anchor(txid, anchor);
+            graph.insert_anchor(txid, anchor, &mut cs);
         }
         if let Some(seen_at) = last_seen {
-            let _ = graph.insert_seen_at(txid, seen_at);
+            graph.insert_seen_at(txid, seen_at, &mut cs);
         }
 
         // check chain position

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -138,16 +138,20 @@ fn test_set_all_derivation_indices() {
         ),
     ]
     .into();
+    let mut changeset = ChangeSet::default();
+    txout_index.reveal_to_target_multi(&derive_to, &mut changeset);
     assert_eq!(
-        txout_index.reveal_to_target_multi(&derive_to),
+        changeset,
         ChangeSet {
             last_revealed: last_revealed.clone(),
             spk_cache: spk_cache.clone(),
         }
     );
     assert_eq!(txout_index.last_revealed_indices(), derive_to);
+    let mut changeset = ChangeSet::default();
+    txout_index.reveal_to_target_multi(&derive_to, &mut changeset);
     assert_eq!(
-        txout_index.reveal_to_target_multi(&derive_to),
+        changeset,
         ChangeSet::default(),
         "no changes if we set to the same thing"
     );
@@ -174,8 +178,9 @@ fn test_lookahead() {
     // - scripts cached in spk_txout_index should increase correctly
     // - stored scripts of external keychain should be of expected counts
     for index in 0..20 {
-        let (revealed_spks, revealed_changeset) = txout_index
-            .reveal_to_target(TestKeychain::External, index)
+        let mut revealed_changeset = ChangeSet::default();
+        let revealed_spks = txout_index
+            .reveal_to_target(TestKeychain::External, index, &mut revealed_changeset)
             .unwrap();
         assert_eq!(
             revealed_spks,
@@ -243,8 +248,9 @@ fn test_lookahead() {
     // expect:
     // - scripts cached in spk_txout_index should increase correctly, a.k.a. no scripts are skipped
     let reveal_to = 24;
-    let (revealed_spks, revealed_changeset) = txout_index
-        .reveal_to_target(TestKeychain::Internal, reveal_to)
+    let mut revealed_changeset = ChangeSet::default();
+    let revealed_spks = txout_index
+        .reveal_to_target(TestKeychain::Internal, reveal_to, &mut revealed_changeset)
         .unwrap();
     assert_eq!(
         revealed_spks,
@@ -419,10 +425,12 @@ fn test_wildcard_derivations() {
     // - derive_new() == ((0, <spk>), keychain::ChangeSet)
     // - next_unused() == ((0, <spk>), keychain::ChangeSet:is_empty())
     assert_eq!(txout_index.next_index(TestKeychain::External).unwrap(), (0, true));
-    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index.reveal_next_spk(TestKeychain::External, &mut changeset).unwrap();
     assert_eq!(spk, (0_u32, external_spk_0.clone()));
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 0)].into());
-    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index.next_unused_spk(TestKeychain::External, &mut changeset).unwrap();
     assert_eq!(spk, (0_u32, external_spk_0.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
@@ -434,7 +442,8 @@ fn test_wildcard_derivations() {
     // - next_derivation_index() = (26, true)
     // - derive_new() = ((26, <spk>), keychain::ChangeSet)
     // - next_unused() == ((16, <spk>), keychain::ChangeSet::is_empty())
-    let _ = txout_index.reveal_to_target(TestKeychain::External, 25);
+    let mut tmp = ChangeSet::default();
+    let _ = txout_index.reveal_to_target(TestKeychain::External, 25, &mut tmp);
 
     (0..=15)
         .chain([17, 20, 23])
@@ -442,12 +451,14 @@ fn test_wildcard_derivations() {
 
     assert_eq!(txout_index.next_index(TestKeychain::External).unwrap(), (26, true));
 
-    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index.reveal_next_spk(TestKeychain::External, &mut changeset).unwrap();
     assert_eq!(spk, (26, external_spk_26));
 
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 26)].into());
 
-    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index.next_unused_spk(TestKeychain::External, &mut changeset).unwrap();
     assert_eq!(spk, (16, external_spk_16));
     assert_eq!(&changeset.last_revealed, &[].into());
 
@@ -457,7 +468,8 @@ fn test_wildcard_derivations() {
         txout_index.mark_used(TestKeychain::External, index);
     });
 
-    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index.next_unused_spk(TestKeychain::External, &mut changeset).unwrap();
     assert_eq!(spk, (27, external_spk_27));
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 27)].into());
 }
@@ -488,14 +500,20 @@ fn test_non_wildcard_derivations() {
         txout_index.next_index(TestKeychain::External).unwrap(),
         (0, true)
     );
-    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index
+        .reveal_next_spk(TestKeychain::External, &mut changeset)
+        .unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(
         &changeset.last_revealed,
         &[(no_wildcard_descriptor.descriptor_id(), 0)].into()
     );
 
-    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index
+        .next_unused_spk(TestKeychain::External, &mut changeset)
+        .unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
@@ -511,15 +529,22 @@ fn test_non_wildcard_derivations() {
     );
     txout_index.mark_used(TestKeychain::External, 0);
 
-    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index
+        .reveal_next_spk(TestKeychain::External, &mut changeset)
+        .unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
-    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
+    let mut changeset = ChangeSet::default();
+    let spk = txout_index
+        .next_unused_spk(TestKeychain::External, &mut changeset)
+        .unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
-    let (revealed_spks, revealed_changeset) = txout_index
-        .reveal_to_target(TestKeychain::External, 200)
+    let mut revealed_changeset = ChangeSet::default();
+    let revealed_spks = txout_index
+        .reveal_to_target(TestKeychain::External, 200, &mut revealed_changeset)
         .unwrap();
     assert_eq!(revealed_spks.len(), 0);
     assert!(revealed_changeset.is_empty());
@@ -593,11 +618,12 @@ fn lookahead_to_target() {
             true,
         );
 
+        let mut tmp = ChangeSet::default();
         if let Some(last_revealed) = t.external_last_revealed {
-            let _ = index.reveal_to_target(TestKeychain::External, last_revealed);
+            let _ = index.reveal_to_target(TestKeychain::External, last_revealed, &mut tmp);
         }
         if let Some(last_revealed) = t.internal_last_revealed {
-            let _ = index.reveal_to_target(TestKeychain::Internal, last_revealed);
+            let _ = index.reveal_to_target(TestKeychain::Internal, last_revealed, &mut tmp);
         }
 
         let keychain_test_cases = [
@@ -624,7 +650,8 @@ fn lookahead_to_target() {
                     }
                     None => target,
                 };
-                let _ = index.lookahead_to_target(keychain.clone(), target);
+                let mut tmp = ChangeSet::default();
+                index.lookahead_to_target(keychain.clone(), target, &mut tmp);
                 let keys: Vec<_> = (0..)
                     .take_while(|&i| index.spk_at_index(keychain.clone(), i).is_some())
                     .collect();
@@ -717,12 +744,13 @@ fn when_querying_over_a_range_of_keychains_the_utxos_should_show_up() {
     let mut indexer = KeychainTxOutIndex::<usize>::new(0, true);
     let mut tx = new_tx(0);
 
+    let mut changeset = ChangeSet::default();
     for (i, descriptor) in DESCRIPTORS.iter().enumerate() {
         let descriptor = parse_descriptor(descriptor);
         let _ = indexer.insert_descriptor(i, descriptor.clone()).unwrap();
         if i != 4 {
             // skip one in the middle to see if uncovers any bugs
-            indexer.reveal_next_spk(i);
+            indexer.reveal_next_spk(i, &mut changeset);
         }
         tx.output.push(TxOut {
             script_pubkey: descriptor.at_derivation_index(0).unwrap().script_pubkey(),

--- a/crates/chain/tests/test_local_chain.rs
+++ b/crates/chain/tests/test_local_chain.rs
@@ -37,18 +37,16 @@ where
     D: bdk_core::ToBlockHash + Copy + PartialEq + std::fmt::Debug,
 {
     fn run(mut self) {
-        let got_changeset = match self.chain.apply_update(self.update) {
-            Ok(changeset) => changeset,
-            Err(got_err) => {
-                assert_eq!(
-                    ExpectedResult::Err(got_err),
-                    self.exp,
-                    "{}: unexpected error",
-                    self.name
-                );
-                return;
-            }
-        };
+        let mut got_changeset = ChangeSet::<D>::default();
+        if let Err(got_err) = self.chain.apply_update(self.update, &mut got_changeset) {
+            assert_eq!(
+                ExpectedResult::Err(got_err),
+                self.exp,
+                "{}: unexpected error",
+                self.name
+            );
+            return;
+        }
 
         match self.exp {
             ExpectedResult::Ok {
@@ -386,9 +384,12 @@ fn local_chain_insert_block() {
     for (i, t) in test_cases.into_iter().enumerate() {
         let mut chain = t.original;
         let block_id: BlockId = t.insert.into();
+        let mut changeset = ChangeSet::default();
+        let result = chain
+            .insert_block(block_id.height, block_id.hash, &mut changeset)
+            .map(|()| changeset);
         assert_eq!(
-            chain.insert_block(block_id.height, block_id.hash),
-            t.expected_result,
+            result, t.expected_result,
             "[{i}] unexpected result when inserting block",
         );
         assert_eq!(chain, t.expected_final, "[{i}] unexpected final chain",);
@@ -481,9 +482,12 @@ fn local_chain_insert_header() {
 
     for (i, t) in test_cases.into_iter().enumerate() {
         let mut chain = t.original;
+        let mut changeset = ChangeSet::default();
+        let result = chain
+            .insert_block(t.insert.0, t.insert.1, &mut changeset)
+            .map(|()| changeset);
         assert_eq!(
-            chain.insert_block(t.insert.0, t.insert.1),
-            t.expected_result,
+            result, t.expected_result,
             "[{i}] unexpected result when inserting block",
         );
         assert_eq!(chain, t.expected_final, "[{i}] unexpected final chain",);
@@ -552,7 +556,10 @@ fn local_chain_disconnect_from() {
 
     for (i, t) in test_cases.into_iter().enumerate() {
         let mut chain = t.original;
-        let result = chain.disconnect_from(t.disconnect_from.into());
+        let mut changeset = ChangeSet::default();
+        let result = chain
+            .disconnect_from(t.disconnect_from.into(), &mut changeset)
+            .map(|()| changeset);
         assert_eq!(
             result, t.exp_result,
             "[{}:{}] unexpected changeset result",
@@ -589,7 +596,10 @@ fn test_apply_update_single_header() {
 
     // Apply 1 `CheckPoint<Header>` at a time
     for (height, header) in (1..).zip([header_1, header_2, header_3]) {
-        let changeset = chain.apply_update(CheckPoint::new(height, header)).unwrap();
+        let mut changeset = ChangeSet::default();
+        chain
+            .apply_update(CheckPoint::new(height, header), &mut changeset)
+            .unwrap();
         assert_eq!(
             changeset,
             ChangeSet {
@@ -609,7 +619,8 @@ fn test_apply_update_single_header() {
     chain = LocalChain::from_blocks([(0, header_0), (1, header_1)].into()).unwrap();
     let mut header_2_alt = header_2;
     header_2_alt.prev_blockhash = hash!("header_1_new");
-    let result = chain.apply_update(CheckPoint::new(2, header_2_alt));
+    let mut changeset = ChangeSet::default();
+    let result = chain.apply_update(CheckPoint::new(2, header_2_alt), &mut changeset);
     assert!(result.is_err(), "Failed to detect prev_blockhash conflict");
 }
 
@@ -961,7 +972,10 @@ fn local_chain_apply_header_connected_to() {
 
     for (i, t) in test_cases.into_iter().enumerate() {
         let mut chain = t.chain;
-        let result = chain.apply_header_connected_to(&t.header, t.height, t.connected_to);
+        let mut changeset = ChangeSet::default();
+        let result = chain
+            .apply_header_connected_to(&t.header, t.height, t.connected_to, &mut changeset)
+            .map(|()| changeset);
         let exp_result = t
             .exp_result
             .map(|cs| cs.iter().cloned().collect::<ChangeSet>());

--- a/crates/chain/tests/test_local_chain.rs
+++ b/crates/chain/tests/test_local_chain.rs
@@ -592,11 +592,12 @@ fn test_apply_update_single_header() {
     let header_2 = headers[2];
     let header_3 = headers[3];
 
-    let (mut chain, _) = LocalChain::from_genesis(header_0);
+    let mut genesis_cs = ChangeSet::<Header>::default();
+    let mut chain = LocalChain::from_genesis(header_0, &mut genesis_cs);
 
     // Apply 1 `CheckPoint<Header>` at a time
     for (height, header) in (1..).zip([header_1, header_2, header_3]) {
-        let mut changeset = ChangeSet::default();
+        let mut changeset = ChangeSet::<Header>::default();
         chain
             .apply_update(CheckPoint::new(height, header), &mut changeset)
             .unwrap();

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -155,8 +155,9 @@ impl<I, D> SyncRequestBuilder<I, D> {
     ///
     /// // Reveal spks for "descriptor_a", then build a sync request. Each spk will be indexed with
     /// // `u32`, which represents the derivation index of the associated spk from "descriptor_a".
-    /// let (newly_revealed_spks, _changeset) = indexer
-    ///     .reveal_to_target("descriptor_a", 21)
+    /// let mut _changeset = bdk_chain::keychain_txout::ChangeSet::default();
+    /// let newly_revealed_spks = indexer
+    ///     .reveal_to_target("descriptor_a", 21, &mut _changeset)
     ///     .expect("keychain must exist");
     /// let _request: SyncRequest<u32, BlockHash> = SyncRequest::builder()
     ///     .spks_with_indexes(newly_revealed_spks)
@@ -225,9 +226,10 @@ impl<I, D> SyncRequestBuilder<I, D> {
 ///
 /// ```rust
 /// # use std::io::{self, Write};
-/// # use bdk_chain::{bitcoin::{hashes::Hash, ScriptBuf}, local_chain::LocalChain};
+/// # use bdk_chain::{bitcoin::{hashes::Hash, ScriptBuf}, local_chain::{ChangeSet, LocalChain}};
 /// # use bdk_chain::spk_client::SyncRequest;
-/// # let (local_chain, _) = LocalChain::from_genesis(Hash::all_zeros());
+/// # let mut genesis_cs = ChangeSet::default();
+/// # let local_chain = LocalChain::from_genesis(Hash::all_zeros(), &mut genesis_cs);
 /// # let scripts = [ScriptBuf::default(), ScriptBuf::default()];
 /// // Construct a sync request.
 /// let sync_request = SyncRequest::builder()

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -83,11 +83,13 @@ where
     )?;
 
     if let Some(chain_update) = update.chain_update.clone() {
-        let _ = chain
-            .apply_update(chain_update)
+        let mut cs = bdk_chain::local_chain::ChangeSet::default();
+        chain
+            .apply_update(chain_update, &mut cs)
             .map_err(|err| anyhow::anyhow!("LocalChain update error: {err:?}"))?;
     }
-    let _ = graph.apply_update(update.tx_update.clone());
+    let mut graph_cs = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.apply_update(update.tx_update.clone(), &mut graph_cs);
 
     Ok(update)
 }
@@ -187,7 +189,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
             .any(|tx| tx.compute_txid() == send_txid),
         "sync response must include the send_tx"
     );
-    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    let mut changeset = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.apply_update(sync_response.tx_update.clone(), &mut changeset);
     assert!(
         changeset.tx_graph.txs.contains(&send_tx),
         "tx graph must deem send_tx relevant and include it"
@@ -217,7 +220,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
             .any(|(txid, _)| *txid == send_txid),
         "sync response must track send_tx as missing from mempool"
     );
-    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    let mut changeset = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.apply_update(sync_response.tx_update.clone(), &mut changeset);
     assert!(
         changeset.tx_graph.last_evicted.contains_key(&send_txid),
         "tx graph must track send_tx as missing"

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -109,7 +109,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = BdkElectrumClient::new(electrum_client);
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
 
     // Get receiving address.
     let receiver_spk = get_test_spk();
@@ -570,7 +571,8 @@ fn test_sync() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut recv_chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -710,7 +712,8 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut recv_chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -796,7 +799,8 @@ fn test_sync_with_coinbase() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut recv_chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -831,7 +835,8 @@ fn test_check_fee_calculation() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let mut recv_chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -699,7 +699,8 @@ mod test {
                     &anchors,
                 )
                 .await?;
-                chain.apply_update(update)?;
+                let mut cs = bdk_chain::local_chain::ChangeSet::default();
+                chain.apply_update(update, &mut cs)?;
                 chain
             };
 
@@ -747,7 +748,8 @@ mod test {
 
             // apply update
             let mut updated_local_chain = local_chain.clone();
-            updated_local_chain.apply_update(update)?;
+            let mut cs = bdk_chain::local_chain::ChangeSet::default();
+            updated_local_chain.apply_update(update, &mut cs)?;
 
             assert!(
                 {

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -670,7 +670,8 @@ mod test {
 
             // craft initial `local_chain`
             let local_chain = {
-                let (mut chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+                let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+                let mut chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
                 // force `chain_update_blocking` to add all checkpoints in `t.initial_cps`
                 let anchors = t
                     .initial_cps

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -661,7 +661,8 @@ mod test {
                     &chain.tip(),
                     &anchors,
                 )?;
-                chain.apply_update(update)?;
+                let mut cs = bdk_chain::local_chain::ChangeSet::default();
+                chain.apply_update(update, &mut cs)?;
                 chain
             };
 
@@ -708,7 +709,8 @@ mod test {
 
             // apply update
             let mut updated_local_chain = local_chain.clone();
-            updated_local_chain.apply_update(update)?;
+            let mut cs = bdk_chain::local_chain::ChangeSet::default();
+            updated_local_chain.apply_update(update, &mut cs)?;
 
             assert!(
                 {
@@ -926,8 +928,9 @@ mod test {
                 t.name
             );
 
-            let _ = chain
-                .apply_update(chain_update)
+            let mut cs = bdk_chain::local_chain::ChangeSet::default();
+            chain
+                .apply_update(chain_update, &mut cs)
                 .unwrap_or_else(|err| panic!("[{}:{}] update failed to apply: {}", i, t.name, err));
 
             // all requested heights must exist in the final chain

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -633,7 +633,8 @@ mod test {
 
             // craft initial `local_chain`
             let local_chain = {
-                let (mut chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+                let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+                let mut chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
                 // force `chain_update_blocking` to add all checkpoints in `t.initial_cps`
                 let anchors = t
                     .initial_cps

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -29,7 +29,8 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_async()?;
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
 
     // Get receiving address.
     let receiver_spk = common::get_test_spk();

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -113,7 +113,8 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
             .any(|tx| tx.compute_txid() == send_txid),
         "sync response must include the send_tx"
     );
-    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    let mut changeset = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.apply_update(sync_response.tx_update.clone(), &mut changeset);
     assert!(
         changeset.tx_graph.txs.contains(&send_tx),
         "tx graph must deem send_tx relevant and include it"
@@ -143,7 +144,8 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
             .any(|(txid, _)| *txid == send_txid),
         "sync response must track send_tx as missing from mempool"
     );
-    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    let mut changeset = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.apply_update(sync_response.tx_update.clone(), &mut changeset);
     assert!(
         changeset.tx_graph.last_evicted.contains_key(&send_txid),
         "tx graph must track send_tx as missing"

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -29,7 +29,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_blocking();
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
+    let mut genesis_cs = bdk_chain::local_chain::ChangeSet::default();
+    let chain = LocalChain::from_genesis(env.genesis_hash()?, &mut genesis_cs);
 
     // Get receiving address.
     let receiver_spk = common::get_test_spk();

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -110,7 +110,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
             .any(|tx| tx.compute_txid() == send_txid),
         "sync response must include the send_tx"
     );
-    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    let mut changeset = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.apply_update(sync_response.tx_update.clone(), &mut changeset);
     assert!(
         changeset.tx_graph.txs.contains(&send_tx),
         "tx graph must deem send_tx relevant and include it"
@@ -140,7 +141,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
             .any(|(txid, _)| *txid == send_txid),
         "sync response must track send_tx as missing from mempool"
     );
-    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    let mut changeset = bdk_chain::indexed_tx_graph::ChangeSet::default();
+    graph.apply_update(sync_response.tx_update.clone(), &mut changeset);
     assert!(
         changeset.tx_graph.last_evicted.contains_key(&send_txid),
         "tx graph must track send_tx as missing"


### PR DESCRIPTION
### Description

This PR refactors the changeset handling pattern across the codebase to use mutable references (`&mut C`) instead of returning `ChangeSet` values. This change affects multiple key APIs:

**Core changes:**
- `IndexedTxGraph` methods (`from_changeset`, `reindex`, `apply_update`, `insert_tx`, `insert_txout`, `insert_anchor`, `insert_seen_at`, `insert_evicted_at`, `batch_insert_*`) now take a mutable changeset reference parameter instead of returning a changeset
- `KeychainTxOutIndex` methods (`reveal_next_spk`, `reveal_to_target`, `reveal_to_target_multi`, `lookahead_to_target`, `next_unused_spk`) now take a mutable changeset reference parameter
- `LocalChain` methods (`from_genesis`, `apply_update`, `apply_header`, `apply_header_connected_to`, `insert_block`, `disconnect_from`) now take a mutable changeset reference parameter

**Key benefits:**
- Eliminates unnecessary allocations and copies of changeset data
- Allows callers to accumulate changes across multiple operations into a single changeset
- Simplifies the API by making it clear that changes are being written into the provided reference
- Enables better control over when changesets are persisted

**API pattern change:**
- Old: `let changeset = graph.insert_tx(tx);`
- New: `let mut changeset = ChangeSet::default(); graph.insert_tx(tx, &mut changeset);`

The refactoring uses a generic `AsMut<ChangeSet>` trait bound to allow flexibility in how changesets are stored and passed around.

### Notes to the reviewers

- All method signatures have been updated consistently across the codebase
- The `from_changeset` method now reads from and writes back to the same changeset reference, making it clear that the changeset is being modified with reindex deltas
- All existing tests have been updated to use the new API pattern
- The change is breaking but provides a cleaner, more efficient API going forward

### Changelog notice

**Breaking Changes:**
- `IndexedTxGraph::from_changeset` now takes a mutable changeset reference parameter and returns `Self` instead of `(Self, ChangeSet)`
- `IndexedTxGraph::reindex` now takes a mutable changeset reference parameter instead of returning a changeset
- All `IndexedTxGraph` mutation methods now take a mutable changeset reference parameter instead of returning a changeset
- `KeychainTxOutIndex` methods that modify state now take a mutable changeset reference parameter instead of returning a changeset
- `LocalChain::from_genesis` now takes a mutable changeset reference parameter and returns `Self` instead of `(Self, ChangeSet)`
- `LocalChain::apply_update` and related methods now take a mutable changeset reference parameter instead of returning a changeset

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

* [x] This pull request breaks the existing API

https://claude.ai/code/session_01ATUB8fmcjzYwTEK1u2UcA6